### PR TITLE
Implemented if-let shorthand syntax throughout the project.

### DIFF
--- a/GitHubFollowers/ViewControllers/FavouritesViewController.swift
+++ b/GitHubFollowers/ViewControllers/FavouritesViewController.swift
@@ -68,12 +68,12 @@ extension FavouritesViewController: UITableViewDelegate {
     
     func tableView(_ tableView: UITableView, trailingSwipeActionsConfigurationForRowAt indexPath: IndexPath) -> UISwipeActionsConfiguration? {
         let deleteAction = UIContextualAction(style: .destructive, title: "Delete") { [weak self] contextAction, view, completion in
-            guard let self = self else { return }
+            guard let self else { return }
             guard let favourite = self.dataSource.itemIdentifier(for: indexPath) else { return }
             
             Task {
                 let error = await PersistenceManager.update(favourite: favourite, withPersistenceAction: .remove)
-                guard let error = error else {
+                guard let error else {
                     self.favourites.removeAll { $0.login == favourite.login }
                     self.updateUI(for: self.favourites)
                     return

--- a/GitHubFollowers/ViewControllers/FollowersViewController.swift
+++ b/GitHubFollowers/ViewControllers/FollowersViewController.swift
@@ -49,12 +49,12 @@ class FollowersViewController: GFDataLoadingViewController {
     
     func configureNavigationBar() {
         let profileAction = UIAction(title: "View Profile", image: SFSymbols.personCircleFill) { [weak self] action in
-            guard let self = self else { return }
+            guard let self else { return }
             self.didSelectProfileOption()
         }
         
         let addAction = UIAction(title: "Favourite User", image: SFSymbols.personFillBadgePlus) { [weak self] action in
-            guard let self = self else { return }
+            guard let self else { return }
             self.didSelectFavouriteOption()
         }
         
@@ -113,7 +113,7 @@ class FollowersViewController: GFDataLoadingViewController {
         
         Task {
             let error = await PersistenceManager.update(favourite: favourite, withPersistenceAction: .add)
-            guard let error = error else {
+            guard let error else {
                 presentUIAlert(title: "Success", message: "You have successfully favourites this user.", buttonTitle: "OK")
                 return
             }

--- a/GitHubFollowers/ViewControllers/UserInfoViewController.swift
+++ b/GitHubFollowers/ViewControllers/UserInfoViewController.swift
@@ -101,7 +101,7 @@ extension UserInfoViewController: UITableViewDelegate {
 extension UserInfoViewController {
     func configureDataSource() {
         dataSource = UserInfoTableViewDiffableDataSource(tableView: tableView) { [weak self] tableView, indexPath, cellType in
-            guard let self = self else { fatalError("Unable to unwrap self.") }
+            guard let self else { fatalError("Unable to unwrap self.") }
             
             switch cellType {
             case .header:


### PR DESCRIPTION
This pull request implements the Swift 5.7 if-let shorthand syntax (also applies to guard lets).
It changes lines like `guard let self = self else { ... }` to `guard let self else { ... }`.